### PR TITLE
Eigen3のパスを指定できるようにする

### DIFF
--- a/choreonoid/rtc/ArmInverseKinematicsTest/src/CMakeLists.txt
+++ b/choreonoid/rtc/ArmInverseKinematicsTest/src/CMakeLists.txt
@@ -2,7 +2,8 @@ set(comp_srcs ArmInverseKinematicsTest.cpp Kinematics.cpp Link.cpp)
 set(standalone_srcs ArmInverseKinematicsTestComp.cpp)
 
 find_package(Boost COMPONENTS system thread filesystem)
-find_package(Eigen3 REQUIRED)
+
+set(EIGEN3_INCLUDE_DIRS $ENV{EIGEN3_INCLUDE_DIRS} CACHE PATH "Eigen installation dir(Default: $EIGEN_HOME)")
 
 if (DEFINED OPENRTM_INCLUDE_DIRS)
   string(REGEX REPLACE "-I" ";"

--- a/choreonoid/rtc/FootInverseKinematicsTest/src/CMakeLists.txt
+++ b/choreonoid/rtc/FootInverseKinematicsTest/src/CMakeLists.txt
@@ -2,7 +2,8 @@ set(comp_srcs FootInverseKinematicsTest.cpp Kinematics.cpp Link.cpp)
 set(standalone_srcs FootInverseKinematicsTestComp.cpp)
 
 find_package(Boost COMPONENTS system thread filesystem)
-find_package(Eigen3 REQUIRED)
+
+set(EIGEN3_INCLUDE_DIRS $ENV{EIGEN3_INCLUDE_DIRS} CACHE PATH "Eigen installation dir(Default: $EIGEN_HOME)")
 
 if (DEFINED OPENRTM_INCLUDE_DIRS)
   string(REGEX REPLACE "-I" ";"
@@ -31,7 +32,7 @@ include_directories(${PROJECT_BINARY_DIR})
 include_directories(${PROJECT_BINARY_DIR}/idl)
 include_directories(${OPENRTM_INCLUDE_DIRS})
 include_directories(${OMNIORB_INCLUDE_DIRS})
-include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(${EIGEN3_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 add_definitions(${OPENRTM_CFLAGS})
 add_definitions(${OMNIORB_CFLAGS})

--- a/choreonoid/rtc/ForwardKinematics/src/CMakeLists.txt
+++ b/choreonoid/rtc/ForwardKinematics/src/CMakeLists.txt
@@ -22,8 +22,9 @@ if (DEFINED OPENRTM_LIBRARIES)
     OPENRTM_LIBRARIES "${OPENRTM_LIBRARIES}")
 endif (DEFINED OPENRTM_LIBRARIES)
 
-set(EIGEN3_INCLUDE_DIR $ENV{EIGEN3_INCLUDE_DIR} CACHE PATH "Eigen installation dir(Default: $EIGEN_HOME)")
-include_directories(${EIGEN3_INCLUDE_DIR})
+set(EIGEN3_INCLUDE_DIRS $ENV{EIGEN3_INCLUDE_DIRS} CACHE PATH "Eigen installation dir(Default: $EIGEN_HOME)")
+
+include_directories(${EIGEN3_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME})
 include_directories(${PROJECT_BINARY_DIR})

--- a/choreonoid/rtc/calcZMPComp/src/CMakeLists.txt
+++ b/choreonoid/rtc/calcZMPComp/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(comp_srcs calcZMP.cpp )
 set(standalone_srcs calcZMPComp.cpp)
 
-find_package(Eigen3 REQUIRED)
+set(EIGEN3_INCLUDE_DIRS $ENV{EIGEN3_INCLUDE_DIRS} CACHE PATH "Eigen installation dir(Default: $EIGEN_HOME)")
 
 if (DEFINED OPENRTM_INCLUDE_DIRS)
   string(REGEX REPLACE "-I" ";"


### PR DESCRIPTION
コンパイル時にeigen3が見つからないという問題を対処．

/etc/envirroment以下にEIGEN3_INCLUDE_DIRS="/usr/include/eigen3"と明記することでパスを自動で見つけられるように修正した．