### PR TITLE
逆運動学計算時のベースリンクIDを変更可能にした

### DIFF
--- a/choreonoid/rtc/ArmInverseKinematicsTest/ArmInverseKinematicsTest.cpp
+++ b/choreonoid/rtc/ArmInverseKinematicsTest/ArmInverseKinematicsTest.cpp
@@ -89,11 +89,11 @@ RTC::ReturnCode_t ArmInverseKinematicsTest::onExecute(RTC::UniqueId ec_id)
 			m_qRef.data[36] += 0.001;
 		}
 
-		RARM_Link.p(0) += m_axes.data[1]*0.1;
-		RARM_Link.p(1) += m_axes.data[0]*0.1;
-		RARM_Link.p(2) += m_axes.data[3]*0.1;
+		RARM_Link.p(0) += m_axes.data[1]*0.5;
+		RARM_Link.p(1) += m_axes.data[0]*0.5;
+		RARM_Link.p(2) += m_axes.data[3]*0.5;
 
-		if(arm->calcInverseKinematics(RARM_JOINT7, RARM_Link)){
+		if(arm->calcInverseKinematics(RARM_JOINT7, CHEST_JOINT2, RARM_Link)){
 			for(int i=13;i<=25;i++)
 				m_qRef.data[i-1] = ulink[i].q;
 		}else{

--- a/choreonoid/rtc/ArmInverseKinematicsTest/Kinematics.cpp
+++ b/choreonoid/rtc/ArmInverseKinematicsTest/Kinematics.cpp
@@ -22,12 +22,12 @@ Matrix<double,3,1> Kinematics::rot2omega(Matrix<double,3,3> R)
 	return 0.5*th/sin(th)*vector_R;
 }
 
-vector<int> Kinematics::FindRoute(int to)
+vector<int> Kinematics::FindRoute(int to, int base)
 {
 	vector<int> idx;
 	int link_num = to;
 
-	while(link_num != 0)
+	while(link_num != base)
 	{
 		idx.push_back(link_num);
 		link_num = ulink[link_num].parent;
@@ -99,7 +99,7 @@ t_matrix Kinematics::PseudoInverse(const t_matrix& m, const double &tolerance)
 	return svd.matrixV()*sigma_inv.asDiagonal()*svd.matrixU().transpose();
 }
 
-bool Kinematics::calcInverseKinematics(int to, Link target)
+bool Kinematics::calcInverseKinematics(int to, int base, Link target)
 {
 	MatrixXd J, dq;
 	Matrix<double,6,1> err;
@@ -111,7 +111,7 @@ bool Kinematics::calcInverseKinematics(int to, Link target)
 	
 	calcForwardKinematics(WAIST);
 	
-	vector<int> idx = FindRoute(to);
+	vector<int> idx = FindRoute(to, base);
 	const int jsize = idx.size();
 	
 	J.resize(6,jsize); dq.resize(jsize,1);

--- a/choreonoid/rtc/ArmInverseKinematicsTest/Kinematics.h
+++ b/choreonoid/rtc/ArmInverseKinematicsTest/Kinematics.h
@@ -23,8 +23,8 @@ namespace MotionControl
 		}
 		void calcForwardKinematics(int rootlink);
 		MatrixXd calcJacobian(vector<int> idx); 
-		bool calcInverseKinematics(int to, Link target);
-		vector<int> FindRoute(int to);
+		bool calcInverseKinematics(int to, int base, Link target);
+		vector<int> FindRoute(int to, int base);
 		Matrix<double,3,3> Rodrigues(Matrix<double,3,1> a, double q);
 		Matrix<double,3,1> rot2omega(Matrix<double,3,3> R);
 		Matrix<double,6,1> calcVWerr(Link Cref, Link Cnow);


### PR DESCRIPTION
従来ではリンクIDが0(vrml上におけるベースリンク)を起点としていたがそのベースリンクIDを関数から変更可能にした

これにより例えばアームのIKが腰リンクベースから胴体リンクベースで計算することが可能になる